### PR TITLE
refactor: removed the unused Client interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,27 +2,11 @@ package client
 
 import (
 	"fmt"
-	"net/http"
 
-	"github.com/crcls/lit-go-sdk/auth"
-	"github.com/crcls/lit-go-sdk/conditions"
 	"github.com/crcls/lit-go-sdk/config"
 )
 
-type Client interface {
-	Connect() (bool, error)
-	GetEncryptionKey(params EncryptedKeyParams) ([]byte, error)
-	NodeRequest(url string, body []byte) (*http.Response, error)
-	SaveEncryptionKey(
-		symmetricKey []byte,
-		authSig auth.AuthSig,
-		authConditions []conditions.EvmContractCondition,
-		chain string,
-		permanent bool,
-	) (string, error)
-}
-
-type ClientFactory struct {
+type Client struct {
 	Config            *config.Config
 	ConnectedNodes    map[string]bool
 	Ready             bool
@@ -33,12 +17,12 @@ type ClientFactory struct {
 	NetworkPubKeySet  string
 }
 
-func New(c *config.Config) (*ClientFactory, error) {
+func New(c *config.Config) (*Client, error) {
 	if c == nil {
 		c = config.New(config.DEFAULT_NETWORK)
 	}
 
-	client := &ClientFactory{
+	client := &Client{
 		Config:            c,
 		ConnectedNodes:    make(map[string]bool),
 		Ready:             false,

--- a/client/conditions.go
+++ b/client/conditions.go
@@ -26,7 +26,7 @@ type SaveCondMsg struct {
 	Err      error
 }
 
-func (c *ClientFactory) StoreEncryptionConditionWithNode(
+func (c *Client) StoreEncryptionConditionWithNode(
 	url string,
 	params SaveCondParams,
 	ch chan SaveCondMsg,

--- a/client/handshake.go
+++ b/client/handshake.go
@@ -13,7 +13,7 @@ type HnskMsg struct {
 	Keys      *ServerKeys
 }
 
-func (c *ClientFactory) Handshake(url string, ch chan HnskMsg) {
+func (c *Client) Handshake(url string, ch chan HnskMsg) {
 	// TODO: make this configurable once supported by the network
 	reqBody, err := json.Marshal(map[string]string{
 		"clientPublicKey": "test",

--- a/client/keys.go
+++ b/client/keys.go
@@ -50,7 +50,7 @@ type DecryptResMsg struct {
 	Err   error
 }
 
-func (c *ClientFactory) GetDecryptionShare(url string, params EncryptedKeyParams, ch chan DecryptResMsg) {
+func (c *Client) GetDecryptionShare(url string, params EncryptedKeyParams, ch chan DecryptResMsg) {
 	reqBody, err := json.Marshal(params)
 	if err != nil {
 		ch <- DecryptResMsg{nil, err}
@@ -87,7 +87,7 @@ type EncryptedKeyParams struct {
 	ToDecrypt             string                             `json:"toDecrypt"`
 }
 
-func (c *ClientFactory) GetEncryptionKey(
+func (c *Client) GetEncryptionKey(
 	params EncryptedKeyParams,
 ) ([]byte, error) {
 	if !c.Ready {
@@ -134,7 +134,7 @@ func (c *ClientFactory) GetEncryptionKey(
 	return crypto.ThresholdDecrypt(shares, params.ToDecrypt, c.NetworkPubKeySet)
 }
 
-func (c *ClientFactory) SaveEncryptionKey(
+func (c *Client) SaveEncryptionKey(
 	symmetricKey []byte,
 	authSig auth.AuthSig,
 	authConditions []conditions.EvmContractCondition,
@@ -208,7 +208,7 @@ func (c *ClientFactory) SaveEncryptionKey(
 	return hex.EncodeToString(key), nil
 }
 
-func (c *ClientFactory) MostCommonKey(name string) (string, error) {
+func (c *Client) MostCommonKey(name string) (string, error) {
 	keyList := make(map[string]int)
 	for _, keys := range c.ServerKeysForNode {
 		k, ok := keys.Key(name)

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -57,7 +57,7 @@ func TestServerKeysKeys(t *testing.T) {
 // }
 
 func TestMostCommonKey(t *testing.T) {
-	client := &ClientFactory{
+	client := &Client{
 		ServerKeysForNode: map[string]ServerKeys{
 			"http://localhost:7470": ServerKeys{
 				ServerPubKey: "common",

--- a/client/network.go
+++ b/client/network.go
@@ -19,7 +19,7 @@ func init() {
 	httpClient = &http.Client{}
 }
 
-func (c *ClientFactory) Connect() (bool, error) {
+func (c *Client) Connect() (bool, error) {
 	nodes := config.NETWORKS[c.Config.Network]
 	ch := make(chan HnskMsg, len(nodes))
 
@@ -73,7 +73,7 @@ func (c *ClientFactory) Connect() (bool, error) {
 	return false, fmt.Errorf("Failed to connect to enough nodes")
 }
 
-func (c *ClientFactory) NodeRequest(ctx context.Context, url string, body []byte) (*http.Response, error) {
+func (c *Client) NodeRequest(ctx context.Context, url string, body []byte) (*http.Response, error) {
 	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("LitClient: Failed to create the request for %s.\n", url)


### PR DESCRIPTION
This was created for testing purposes at first. I've figured out a much more efficient way of testing the Client struct, so this is obsolete.