### PR TITLE
Add docker dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM curlimages/curl:latest
+
+WORKDIR /tmp
+RUN curl -L https://github.com/cortesi/modd/releases/download/v0.8/modd-0.8-linux64.tgz | tar xvz
+
+FROM golang:1.18.4
+
+COPY --from=0 /tmp/modd-0.8-linux64/modd /usr/local/bin
+
+RUN mkdir /tmp/cache
+ENV GOMODCACHE=/tmp/cache
+
+WORKDIR /go/src
+
+CMD ["modd"]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ Golang SDK for the Lit Protocol. Backed by a small grant from
 LitProtocol.
 
 https://github.com/LIT-Protocol/LitGrants/issues/11
+
+## Dev Environment.
+
+1. Make sure you have Docker installed.
+2. Run `docker compose up --build` the first time to build the
+   container and run the test suite. The tests will automatically
+   reload when a file is changed.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,12 +1,20 @@
 package client
 
-import "testing"
+import (
+	"testing"
 
-func init() {
-	testResponse = testKeys
+	"github.com/crcls/lit-go-sdk/config"
+)
+
+var testConfig = &config.Config{
+	MinimumNodeCount: 1,
+	Network:          "localhost",
+	RequestTimeout:   config.REQUEST_TIMEOUT,
+	Version:          config.VERSION,
 }
 
-func TestNewDefaultConfig(t *testing.T) {
+func TestNewWithDefaultConfig(t *testing.T) {
+	httpClient = &MockHttpClient{testKeys}
 	c, err := New(nil)
 
 	if err != nil {
@@ -14,6 +22,19 @@ func TestNewDefaultConfig(t *testing.T) {
 	}
 
 	if c.Config.Network != "jalapeno" {
+		t.Errorf("Unexpected network value: %s", c.Config.Network)
+	}
+}
+
+func TestNewWithConfig(t *testing.T) {
+	httpClient = &MockHttpClient{testKeys}
+	c, err := New(config.New("localhost"))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+
+	if c.Config.Network != "localhost" {
 		t.Errorf("Unexpected network value: %s", c.Config.Network)
 	}
 }

--- a/client/conditions_test.go
+++ b/client/conditions_test.go
@@ -7,29 +7,27 @@ import (
 	"github.com/crcls/lit-go-sdk/config"
 )
 
-func init() {
-	testResponse = `{
-		"result": "success",
-		"error": ""
-	}`
+var params = SaveCondParams{
+	Key: "key",
+	Val: "val",
+	AuthSig: auth.AuthSig{
+		Sig:           "sig",
+		DerivedVia:    "derivedVia",
+		SignedMessage: "signedMessage",
+		Address:       "address",
+	},
+	Chain:     "chain",
+	Permanent: 0,
 }
 
 func TestStoreEncryptionConditionWithNode(t *testing.T) {
+	httpClient = &MockHttpClient{`{
+		"result": "success",
+		"error": ""
+	}`}
+
 	c, _ := New(config.New("localhost"))
 	ch := make(chan SaveCondMsg, 1)
-
-	params := SaveCondParams{
-		Key: "key",
-		Val: "val",
-		AuthSig: auth.AuthSig{
-			Sig:           "sig",
-			DerivedVia:    "derivedVia",
-			SignedMessage: "signedMessage",
-			Address:       "address",
-		},
-		Chain:     "chain",
-		Permanent: 0,
-	}
 
 	c.StoreEncryptionConditionWithNode("/test", params, ch)
 
@@ -37,6 +35,10 @@ func TestStoreEncryptionConditionWithNode(t *testing.T) {
 	case msg := <-ch:
 		if msg.Err != nil {
 			t.Errorf("Unexpected error: %s", msg.Err.Error())
+		} else if msg.Response.Result != "success" {
+			t.Errorf("Unexpected response result: %s", msg.Response.Result)
+		} else if msg.Response.Error != "" {
+			t.Errorf("Unexpected response error: %s", msg.Response.Error)
 		}
 	}
 }

--- a/client/handshake_test.go
+++ b/client/handshake_test.go
@@ -6,18 +6,8 @@ import (
 	"github.com/crcls/lit-go-sdk/config"
 )
 
-var testKeys = `{
-	"serverPublicKey": "ServerPubKey",
-	"subnetPublicKey": "SubnetPubKey",
-	"networkPublicKey": "NetworkPubKey",
-	"networkPublicKeySet": "NetworkPubKeySet"
-}`
-
-func init() {
-	testResponse = testKeys
-}
-
 func TestHandshake(t *testing.T) {
+	httpClient = &MockHttpClient{testKeys}
 	c, _ := New(config.New("localhost"))
 	ch := make(chan HnskMsg, 1)
 
@@ -29,7 +19,7 @@ func TestHandshake(t *testing.T) {
 			t.Errorf("Handshake returned false connection")
 		} else if msg.Keys == nil {
 			t.Errorf("Handshake response keys are nil")
-		} else if msg.Keys.NetworkPubKeySet != "NetworkPubKeySet" {
+		} else if msg.Keys.NetworkPubKeySet != "networkPubKeySet" {
 			t.Errorf("Unexpected NetworkPubKeySet key %s", msg.Keys.NetworkPubKeySet)
 		}
 	}

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -4,6 +4,13 @@ import (
 	"testing"
 )
 
+var testKeys = `{
+	"serverPublicKey": "serverPubKey",
+	"subnetPublicKey": "subnetPubKey",
+	"networkPublicKey": "networkPubKey",
+	"networkPublicKeySet": "networkPubKeySet"
+}`
+
 func TestServerKeysKeys(t *testing.T) {
 	sk := ServerKeys{
 		"serverPubKey",

--- a/client/network_test.go
+++ b/client/network_test.go
@@ -22,12 +22,6 @@ func (mhc *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-var testResponse string
-
-func init() {
-	httpClient = &MockHttpClient{testResponse}
-}
-
 func TestConnect(t *testing.T) {
 	_, err := New(config.New("localhost"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: lit-go-sdk-dev
+    image: lit-go-sdk
+    environment:
+      ENV: development
+      LIT_VERSION: '1.1.228'
+    volumes:
+      - '.:/go/src'
+      - './.cache:/tmp/cache'

--- a/modd.conf
+++ b/modd.conf
@@ -1,0 +1,4 @@
+**/*.go {
+  prep: go test -v -coverprofile coverage.out ./...
+  prep: go tool cover -html coverage.out -o coverage.html
+}

--- a/types.go
+++ b/types.go
@@ -1,5 +1,0 @@
-package lit
-
-import "net/http"
-
-type SendReqFuncType func(url string, body []byte) (*http.Response, error)


### PR DESCRIPTION
This PR adds the Docker dev env for testing while you work. This also addresses an issue in the client test suite where the `testResponse` variable was not properly overwriting the previous test value.